### PR TITLE
I've updated the GitHub Actions workflow for you.

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyqt5 pyautogui pyinstaller pystray pillow
+          pip install -r requirements.txt
 
       - name: Build app
         run: |


### PR DESCRIPTION
The workflow in `.github/workflows/build-and-commit.yml` will now install Python dependencies from `requirements.txt`.

This ensures that the CI build process uses the same centralized dependency list as your local development, incorporating the `pyinstaller` package and specific versions defined in `requirements.txt`.

The rest of the workflow, including the PyInstaller build command, README update logic, and GPG signing steps, remains unchanged.